### PR TITLE
don't unfocus focused client when starting a drag

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -2265,9 +2265,6 @@ void
 startdrag(struct wl_listener *listener, void *data)
 {
 	struct wlr_drag *drag = data;
-	/* During drag the focus isn't sent to clients, this causes that
-	 * we don't update border color acording the pointer coordinates */
-	focusclient(NULL, 0);
 
 	if (!drag->icon)
 		return;


### PR DESCRIPTION
this fix chromium keyboard focus loss after a drag
Fix: 3cc22de712415342e4865eef099fcfde49bcf734